### PR TITLE
chore: updating code first tests

### DIFF
--- a/packages/apollo/package.json
+++ b/packages/apollo/package.json
@@ -26,6 +26,7 @@
     "@apollo/gateway": "0.54.1",
     "@apollo/gateway-v2": "npm:@apollo/gateway@2.2.3",
     "@apollo/subgraph-v2": "npm:@apollo/subgraph@2.2.3",
+    "@apollo/server-plugin-response-cache": "^4.1.0",
     "@nestjs/common": "9.2.1",
     "@nestjs/core": "9.2.1",
     "@nestjs/platform-express": "9.2.1",
@@ -34,7 +35,6 @@
     "apollo-cache-inmemory": "1.6.6",
     "apollo-client": "2.6.10",
     "apollo-link-ws": "1.0.20",
-    "apollo-server-plugin-response-cache": "3.8.1",
     "graphql-16": "npm:graphql@16.6.0"
   },
   "dependencies": {

--- a/packages/apollo/tests/code-first-federation/caching.module.ts
+++ b/packages/apollo/tests/code-first-federation/caching.module.ts
@@ -5,7 +5,7 @@ import {
   GraphQLEnumType,
   GraphQLInt,
 } from 'graphql';
-import responseCachePlugin from 'apollo-server-plugin-response-cache';
+import responseCachePlugin from '@apollo/server-plugin-response-cache';
 import { ApolloServerPluginInlineTraceDisabled } from '@apollo/server/plugin/disabled';
 import { Module } from '@nestjs/common';
 import { GraphQLModule } from '@nestjs/graphql';

--- a/packages/apollo/tests/e2e/code-first-federation-caching.spec.ts
+++ b/packages/apollo/tests/e2e/code-first-federation-caching.spec.ts
@@ -70,7 +70,7 @@ describe('Code-first - Federation with caching', () => {
       );
 
       introspectionSchema = await (
-        await graphql(schema, getIntrospectionQuery())
+        await graphql({ schema, source: getIntrospectionQuery() })
       ).data.__schema;
     });
 
@@ -87,7 +87,7 @@ describe('Code-first - Federation with caching', () => {
 
   describe('enabled cache', () => {
     let app: INestApplication;
-    let apolloClient: ApolloServerBase;
+    let apolloClient: ApolloServer;
     let postService: PostService;
 
     beforeEach(async () => {

--- a/packages/apollo/tests/e2e/code-first-federation.spec.ts
+++ b/packages/apollo/tests/e2e/code-first-federation.spec.ts
@@ -1,10 +1,11 @@
-import { ApolloServer } from '@apollo/server';
+import { ApolloServer, GraphQLResponse } from '@apollo/server';
 import { INestApplication } from '@nestjs/common';
 import { GraphQLModule } from '@nestjs/graphql';
 import { Test } from '@nestjs/testing';
 import { gql } from 'graphql-tag';
 import { ApolloFederationDriver } from '../../lib';
 import { ApplicationModule } from '../code-first-federation/app.module';
+import { expectSingleResult } from '../utils/assertion-utils';
 
 describe('Code-first - Federation', () => {
   let app: INestApplication;
@@ -116,7 +117,7 @@ union FederationSearchResultUnion = Post | User
         }
       `,
     });
-    expect(response.data).toEqual({
+    expectSingleResult(response).toEqual({
       recipe: {
         id: '1',
         title: 'Recipe',

--- a/packages/apollo/tests/e2e/code-first-federation.spec.ts
+++ b/packages/apollo/tests/e2e/code-first-federation.spec.ts
@@ -33,7 +33,7 @@ describe('Code-first - Federation', () => {
         }
       `,
     });
-    expect(response.data).toEqual({
+    expectSingleResult(response).toEqual({
       _service: {
         sdl: `interface IRecipe {
   id: ID!
@@ -89,7 +89,7 @@ union FederationSearchResultUnion = Post | User
         }
       `,
     });
-    expect(response.data).toEqual({
+    expectSingleResult(response).toEqual({
       search: [
         {
           id: '1',

--- a/packages/apollo/tests/e2e/code-first-schema.spec.ts
+++ b/packages/apollo/tests/e2e/code-first-schema.spec.ts
@@ -68,7 +68,7 @@ describe('Code-first - schema factory', () => {
       debugger;
       expect(schema).toBeInstanceOf(GraphQLSchema);
     });
-    xit('should match schema snapshot', () => {
+    it('should match schema snapshot', () => {
       expect(GRAPHQL_SDL_FILE_HEADER + printSchema(schema)).toEqual(
         printedSchemaSnapshot,
       );

--- a/packages/apollo/tests/e2e/code-first.spec.ts
+++ b/packages/apollo/tests/e2e/code-first.spec.ts
@@ -5,7 +5,7 @@ import { ApolloServer } from '@apollo/server';
 import { gql } from 'graphql-tag';
 import { ApolloDriver } from '../../lib';
 import { ApplicationModule } from '../code-first/app.module';
-import * as assert from 'assert';
+import { expectSingleResult } from '../utils/assertion-utils';
 
 describe('Code-first', () => {
   let app: INestApplication;
@@ -34,9 +34,7 @@ describe('Code-first', () => {
         }
       `,
     });
-    assert(response.body.kind === 'single');
-    expect(response.body.singleResult.errors).toBeUndefined();
-    expect(response.body.singleResult.data).toEqual({
+    expectSingleResult(response).toEqual({
       categories: [
         {
           name: 'Category #1',
@@ -62,9 +60,7 @@ describe('Code-first', () => {
         }
       `,
     });
-    assert(response.body.kind === 'single');
-    expect(response.body.singleResult.errors).toBeUndefined();
-    expect(response.body.singleResult.data).toEqual({
+    expectSingleResult(response).toEqual({
       search: [
         {
           title: 'recipe',
@@ -93,9 +89,7 @@ describe('Code-first', () => {
         }
       `,
     });
-    assert(response.body.kind === 'single');
-    expect(response.body.singleResult.errors).toBeUndefined();
-    expect(response.body.singleResult.data).toEqual({
+    expectSingleResult(response).toEqual({
       recipes: [
         {
           id: '1',
@@ -140,9 +134,7 @@ describe('Code-first', () => {
         }
       `,
     });
-    assert(response.body.kind === 'single');
-    expect(response.body.singleResult.errors).toBeUndefined();
-    expect(response.body.singleResult.data).toEqual({
+    expectSingleResult(response).toEqual({
       recipes: [
         {
           id: '1',

--- a/packages/apollo/tests/e2e/graphql-sort-schema.spec.ts
+++ b/packages/apollo/tests/e2e/graphql-sort-schema.spec.ts
@@ -55,5 +55,4 @@ type Query {
 
 type Subscription {
   catCreated: Cat
-}
-`;
+}`;

--- a/packages/apollo/tests/utils/assertion-utils.ts
+++ b/packages/apollo/tests/utils/assertion-utils.ts
@@ -1,0 +1,13 @@
+import { GraphQLResponse } from '@apollo/server';
+import assert from 'assert';
+import exp from 'constants';
+
+const expectSingleResult = <TData = Record<string, unknown>>(
+  response: GraphQLResponse<TData>,
+) => {
+  assert(response.body.kind === 'single');
+  expect(response.body.singleResult.errors).toBeUndefined();
+  return expect(response.body.singleResult.data);
+};
+
+export { expectSingleResult };

--- a/packages/apollo/tests/utils/assertion-utils.ts
+++ b/packages/apollo/tests/utils/assertion-utils.ts
@@ -1,6 +1,5 @@
 import { GraphQLResponse } from '@apollo/server';
-import assert from 'assert';
-import exp from 'constants';
+import * as assert from 'assert';
 
 const expectSingleResult = <TData = Record<string, unknown>>(
   response: GraphQLResponse<TData>,

--- a/packages/apollo/tests/utils/printed-schema-with-cache-control.snapshot.ts
+++ b/packages/apollo/tests/utils/printed-schema-with-cache-control.snapshot.ts
@@ -41,5 +41,4 @@ type User {
 enum CacheControlScope {
   PUBLIC
   PRIVATE
-}
-`;
+}`;

--- a/packages/apollo/tests/utils/printed-schema.snapshot.ts
+++ b/packages/apollo/tests/utils/printed-schema.snapshot.ts
@@ -112,8 +112,7 @@ input NewRecipeInput {
 type Subscription {
   """subscription description"""
   recipeAdded: Recipe!
-}
-`;
+}`;
 
 export const sortedPrintedSchemaSnapshot = `# ------------------------------------------------------
 # THIS FILE WAS AUTOMATICALLY GENERATED (DO NOT MODIFY)

--- a/packages/apollo/tests/utils/printed-schema.snapshot.ts
+++ b/packages/apollo/tests/utils/printed-schema.snapshot.ts
@@ -210,5 +210,4 @@ union SearchResultUnion = Ingredient | Recipe
 type Subscription {
   """subscription description"""
   recipeAdded: Recipe!
-}
-`;
+}`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -169,6 +169,14 @@
     "@apollo/utils.keyvaluecache" "^2.1.0"
     "@apollo/utils.logger" "^2.0.0"
 
+"@apollo/server-plugin-response-cache@^4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@apollo/server-plugin-response-cache/-/server-plugin-response-cache-4.1.0.tgz#2c6752bec3bb14d2901688ae631220fd37b938a2"
+  integrity sha512-Nv3WUnpb0PV22D6ayY1vv+9mJPPju0uk4imRo7TS5N9nVy+OEKJ7VW6VJ/XA4+1h0CUKkRX6Tb0BrgJuRYFR1Q==
+  dependencies:
+    "@apollo/utils.createhash" "^2.0.0"
+    "@apollo/utils.keyvaluecache" "^2.1.0"
+
 "@apollo/server@^4.3.2":
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/@apollo/server/-/server-4.3.2.tgz#f2852f5b8f6266116fa93dc90e499cdaec6fa0f8"
@@ -3138,23 +3146,7 @@ apollo-server-env@^4.2.1:
   dependencies:
     node-fetch "^2.6.7"
 
-apollo-server-plugin-base@^3.7.1:
-  version "3.7.1"
-  resolved "https://registry.yarnpkg.com/apollo-server-plugin-base/-/apollo-server-plugin-base-3.7.1.tgz#aa78ef49bd114e35906ca9cf7493fed2664cbde8"
-  integrity sha512-g3vJStmQtQvjGI289UkLMfThmOEOddpVgHLHT2bNj0sCD/bbisj4xKbBHETqaURokteqSWyyd4RDTUe0wAUDNQ==
-  dependencies:
-    apollo-server-types "^3.7.1"
-
-apollo-server-plugin-response-cache@3.8.1:
-  version "3.8.1"
-  resolved "https://registry.yarnpkg.com/apollo-server-plugin-response-cache/-/apollo-server-plugin-response-cache-3.8.1.tgz#2d9559fe9951812dcda77fc2658422028f060af8"
-  integrity sha512-c6bkrZjzX8Ac44CF7a4m9ans2QFV2C0XVUUDnuSWAX3G9ZWbs55NC+H3YtcFhAPoX7gv92RAu88ipMahd8NiUQ==
-  dependencies:
-    "@apollo/utils.keyvaluecache" "^1.0.1"
-    apollo-server-plugin-base "^3.7.1"
-    apollo-server-types "^3.7.1"
-
-apollo-server-types@^3.0.2, apollo-server-types@^3.7.1:
+apollo-server-types@^3.0.2:
   version "3.7.1"
   resolved "https://registry.yarnpkg.com/apollo-server-types/-/apollo-server-types-3.7.1.tgz#87adfcb52ec0893999a9cfafd5474bfda7ab0798"
   integrity sha512-aE9RDVplmkaOj/OduNmGa+0a1B5RIWI0o3zC1zLvBTVWMKTpo0ifVf11TyMkLCY+T7cnZqVqwyShziOyC3FyUw==


### PR DESCRIPTION
- Updated code first tests for standard, federation, schema and caching. Removed TODO from code first schema.
- Updated printed schema payload according to changes on graphql 16.x (https://github.com/graphql/graphql-js/pull/2997)
- Added assertion utils to provide a `expectSingleResult` convenience method.
- Migrated to new @apollo/server-plugin-response-cache lib 

